### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/apps/web/src/app/modules/cases/cases.controller.ts
+++ b/apps/web/src/app/modules/cases/cases.controller.ts
@@ -27,6 +27,16 @@ export class CasesController {
   @Get(':id')
   @Render('cases/detail')
   async findOne(@Param('id') id: string) {
+    // Validate the id parameter to ensure it only contains alphanumeric characters
+    const isValidId = /^[a-zA-Z0-9]+$/.test(id);
+    if (!isValidId) {
+      return {
+        case: null,
+        events: [],
+        error: 'Invalid case ID',
+        title: 'Case Details',
+      };
+    }
     try {
       const { data: caseData } = await axios.get(
         `${this.apiUrl}/api/cases/${id}`,


### PR DESCRIPTION
Potential fix for [https://github.com/MattMencel/bizlaw/security/code-scanning/2](https://github.com/MattMencel/bizlaw/security/code-scanning/2)

To fix the problem, we need to ensure that the `id` parameter is validated before it is used to construct the URL for the outgoing HTTP request. One way to do this is to use a whitelist of allowed `id` values or to validate the `id` against a specific pattern that ensures it is safe. This will prevent attackers from injecting malicious values into the URL.

The best way to fix the problem without changing existing functionality is to add a validation step for the `id` parameter before it is used in the `axios.get` calls. We can use a regular expression to ensure that the `id` only contains alphanumeric characters, which should be sufficient for this use case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
