### PR TITLE
Potential fix for code scanning alert no. 31: Insecure Mass Assignment

### DIFF
--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -239,7 +239,14 @@ class SimulationsController < ApplicationController
       :plaintiff_min_acceptable, :plaintiff_ideal,
       :defendant_ideal, :defendant_max_acceptable,
       :total_rounds, :pressure_escalation_rate,
-      simulation_config: {}
+      simulation_config: [
+        :client_mood_enabled,
+        :pressure_escalation_enabled,
+        :auto_round_advancement,
+        :settlement_range_hints,
+        :arbitration_threshold_rounds,
+        :round_duration_hours
+      ]
     )
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/MattMencel/bizlaw/security/code-scanning/31](https://github.com/MattMencel/bizlaw/security/code-scanning/31)

To remove the insecure mass assignment, we need to restrict which keys inside `simulation_config` are permitted. Instead of `simulation_config: {}` (which allows arbitrary keys), use `simulation_config: {...}` with an explicit list of allowed config keys. The fix requires editing the `simulation_params` method in `app/controllers/simulations_controller.rb`, replacing the open hash with the names of the permitted config keys.

Steps:
- Determine the expected safe keys for `simulation_config`. From the method `default_simulation_config` (lines 259-266), the keys are:
  - `"client_mood_enabled"`
  - `"pressure_escalation_enabled"`
  - `"auto_round_advancement"`
  - `"settlement_range_hints"`
  - `"arbitration_threshold_rounds"`
  - `"round_duration_hours"`
- Permit only these keys inside `simulation_config` by listing them in the `permit` call.

No extra methods, dependencies, or imports are required; simply update the argument to `permit` in `simulation_params`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
