### PR TITLE
fix(ci): bump brakeman to 8.0.6 and drop --ensure-latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.1)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bullet (8.0.8)

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
## Problem

The CI `lint` job fails at the Brakeman step with exit code 5 and `Brakeman 7.1.1 is not the latest version 8.0.6`.

`bin/brakeman` (the Rails 8 default binstub) did `ARGV.unshift("--ensure-latest")`, which makes Brakeman exit 5 whenever the installed gem is behind the newest published version. `Gemfile.lock` pinned brakeman 7.1.1; rubygems has 8.0.6. This is unrelated to any application code — it fails on every PR that triggers the lint job, and re-breaks each time Brakeman publishes a release ahead of the lockfile.

The pre-commit hook passed throughout because it calls `bundle exec brakeman --no-exit-on-warn --no-pager` directly, without `--ensure-latest`.

## Changes

- `Gemfile.lock`: brakeman 7.1.1 → 8.0.6
- `bin/brakeman`: drop `ARGV.unshift("--ensure-latest")` so the lint job fails only on real findings. Dependabot keeps the gem current like any other dependency.

## Verification

`bin/brakeman --no-pager --no-exit-on-warn` exits 0.

Brakeman 8 is a major bump, so the warning set was diffed against the 7.1.1 baseline. Scan totals are unchanged (48 controllers, 28 models, 126 templates, 0 errors). Security warnings went 7 → 6 — **no new findings**. The one that disappeared is the `EOLRails` notice on `Gemfile.lock` ("Support for Rails 8.0.2.1 ends on 2026-10-07"), which v8's updated EOL data no longer flags.

The remaining 6 are all pre-existing:

| Confidence | Check | Location |
| --- | --- | --- |
| Medium | Mass Assignment (PermitAttributes) | `app/controllers/admin/users_controller.rb:87` |
| Medium | Mass Assignment (PermitAttributes) | `app/controllers/invitations_controller.rb:105` |
| Medium | Mass Assignment (PermitAttributes) | `app/controllers/invitations_controller.rb:109` |
| Medium | Mass Assignment (PermitAttributes) | `app/controllers/team_members_controller.rb:164` |
| Weak | Cross-Site Scripting | `app/views/scoring_dashboard/student_index.html.erb:368` |
| Weak | File Access | `app/controllers/negotiations_controller.rb:343` |

## Noted, not fixed

`.github/workflows/ci.yml:54` interpolates `${{ needs.changed.outputs.all_changed_files }}` directly into a `run:` step, which is the shell-injection pattern that belongs behind an `env:` block. Out of scope here — worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)