### PR TITLE
fix(security): authorize case creation against the target course

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -4,6 +4,8 @@ class CasesController < ApplicationController
   before_action :set_course, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_case, only: [:show, :edit, :update, :destroy]
   before_action :authorize_case, only: [:show, :edit, :update, :destroy]
+  before_action :authorize_new_case, only: [:new, :create]
+  after_action :verify_authorized, except: [:index]
 
   def index
     if params[:course_id]
@@ -95,6 +97,7 @@ class CasesController < ApplicationController
       set_case
       authorize_case
     else
+      skip_authorization
       @cases = Case.accessible_by(current_user).page(params[:page])
     end
   end
@@ -105,6 +108,7 @@ class CasesController < ApplicationController
       authorize_case
       @events = @case.case_events.order(:created_at)
     else
+      skip_authorization
       @cases = Case.accessible_by(current_user).page(params[:page])
     end
   end
@@ -115,6 +119,7 @@ class CasesController < ApplicationController
       authorize_case
       @events = @case.case_events.order(:created_at)
     else
+      skip_authorization
       @cases = Case.accessible_by(current_user).page(params[:page])
     end
   end
@@ -186,5 +191,11 @@ class CasesController < ApplicationController
 
   def authorize_case
     authorize @case
+  end
+
+  # new/create have no persisted record yet, so authorize a stand-in carrying
+  # the target course. CasePolicy#create? verifies the user can manage it.
+  def authorize_new_case
+    authorize Case.new(course: @course), :create?
   end
 end

--- a/app/policies/case_policy.rb
+++ b/app/policies/case_policy.rb
@@ -13,8 +13,15 @@ class CasePolicy < ApplicationPolicy
     user_can_access_case?
   end
 
+  def new?
+    create?
+  end
+
   def create?
-    user.instructor? || user.admin?
+    return false unless user.instructor? || user.admin?
+    return true if user.admin?
+
+    user_can_manage_record_course?
   end
 
   def edit?
@@ -59,6 +66,16 @@ class CasePolicy < ApplicationPolicy
   end
 
   private
+
+  # Used for create/new, where the record is an unsaved Case whose only
+  # meaningful attribute is the course it would belong to.
+  def user_can_manage_record_course?
+    course = record.respond_to?(:course) ? record.course : nil
+    return false unless course
+    return true if course.instructor_id == user.id
+
+    user.can_manage_organization?(course.organization)
+  end
 
   def user_can_access_case?
     return true if user.admin?

--- a/spec/policies/case_policy_spec.rb
+++ b/spec/policies/case_policy_spec.rb
@@ -57,19 +57,50 @@ RSpec.describe CasePolicy, type: :policy do
   end
 
   describe "#create?" do
+    # NOTE: role predicates read the `roles` array column, so these use the
+    # factory traits rather than `role:` like the older examples above.
+    let(:course_owner) { build_stubbed(:user, :instructor) }
+    let(:other_instructor) { build_stubbed(:user, :instructor) }
+    let(:site_admin) { build_stubbed(:user, :admin) }
+    let(:enrolled_student) { build_stubbed(:user, :student) }
+    let(:own_course) { build_stubbed(:course, instructor: course_owner) }
+    let(:other_course) { build_stubbed(:course, instructor: other_instructor) }
+
     it "permits admin to create cases" do
-      policy = described_class.new(admin, Case)
+      policy = described_class.new(site_admin, Case.new(course: own_course))
       expect(policy.create?).to be true
     end
 
-    it "permits instructor to create cases" do
-      policy = described_class.new(instructor, Case)
+    it "permits admin to create cases without a course" do
+      policy = described_class.new(site_admin, Case.new)
       expect(policy.create?).to be true
+    end
+
+    it "permits instructor to create cases in their own course" do
+      policy = described_class.new(course_owner, Case.new(course: own_course))
+      expect(policy.create?).to be true
+    end
+
+    it "denies instructor creating cases in another instructor's course" do
+      policy = described_class.new(course_owner, Case.new(course: other_course))
+      expect(policy.create?).to be false
+    end
+
+    it "denies instructor creating cases with no course" do
+      policy = described_class.new(course_owner, Case.new)
+      expect(policy.create?).to be false
     end
 
     it "denies student access to create cases" do
-      policy = described_class.new(student, Case)
+      policy = described_class.new(enrolled_student, Case.new(course: own_course))
       expect(policy.create?).to be false
+    end
+
+    describe "#new?" do
+      it "mirrors #create?" do
+        expect(described_class.new(course_owner, Case.new(course: own_course)).new?).to be true
+        expect(described_class.new(course_owner, Case.new(course: other_course)).new?).to be false
+      end
     end
   end
 

--- a/spec/requests/cases_spec.rb
+++ b/spec/requests/cases_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe "Cases", type: :request do
     context "when user has access to case" do
       before do
         sign_in instructor
-        allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
       end
 
       it "returns successful response" do
@@ -101,7 +100,6 @@ RSpec.describe "Cases", type: :request do
   describe "GET /courses/:course_id/cases/new" do
     before do
       sign_in instructor
-      allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
     end
 
     context "without scenario_id" do
@@ -206,7 +204,6 @@ RSpec.describe "Cases", type: :request do
 
     before do
       sign_in instructor
-      allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
     end
 
     context "with valid parameters" do
@@ -291,7 +288,6 @@ RSpec.describe "Cases", type: :request do
   describe "GET /courses/:course_id/cases/:id/edit" do
     before do
       sign_in instructor
-      allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
     end
 
     it "returns successful response" do
@@ -323,7 +319,6 @@ RSpec.describe "Cases", type: :request do
 
     before do
       sign_in instructor
-      allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
     end
 
     context "with valid parameters" do
@@ -389,7 +384,6 @@ RSpec.describe "Cases", type: :request do
   describe "DELETE /courses/:course_id/cases/:id" do
     before do
       sign_in instructor
-      allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
       case_instance # Create the case
     end
 
@@ -493,7 +487,6 @@ RSpec.describe "Cases", type: :request do
     describe "#set_case" do
       before do
         sign_in instructor
-        allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)
       end
 
       context "with course_id parameter" do
@@ -582,33 +575,140 @@ RSpec.describe "Cases", type: :request do
     end
   end
 
-  describe "authorization integration" do
-    context "when student tries to create case" do
-      before { sign_in student }
+  describe "authorization on new/create" do
+    # The first instructor created in an organization is auto-promoted to
+    # org_admin (User#assign_first_instructor_as_org_admin), and org admins are
+    # allowed to manage every course in their org. Strip the role so these
+    # examples exercise a plain instructor.
+    let(:other_instructor) do
+      create(:user, :instructor, organization: organization).tap { |u| u.remove_role("org_admin") }
+    end
+    let(:other_course) do
+      create(:course, instructor: other_instructor, organization: organization, course_code: "OTHER101")
+    end
+    let(:plain_instructor) do
+      create(:user, :instructor, organization: organization).tap { |u| u.remove_role("org_admin") }
+    end
 
-      it "checks authorization" do
-        # This test verifies that authorization is checked during case creation
-        # For a student trying to create a case, this should either succeed (if authorized)
-        # or fail with proper authorization handling
-        post course_cases_path(course), params: {case: {title: "Test"}}
-        expect(response.status).to be_in([201, 302, 403, 422])
+    let(:valid_params) do
+      {
+        title: "New Legal Case",
+        description: "A test case description",
+        case_type: "sexual_harassment",
+        difficulty_level: "intermediate",
+        legal_issues: ["Sexual harassment"],
+        plaintiff_info_keys: ["name"],
+        plaintiff_info_values: ["John Doe"],
+        defendant_info_keys: ["company"],
+        defendant_info_values: ["TechCorp"]
+      }
+    end
+
+    context "when the instructor owns the course" do
+      let(:own_course) do
+        create(:course, instructor: plain_instructor, organization: organization, course_code: "OWN101")
+      end
+
+      before { sign_in plain_instructor }
+
+      it "creates the case" do
+        expect {
+          post course_cases_path(own_course), params: {case: valid_params}
+        }.to change(Case, :count).by(1)
+
+        expect(response).to redirect_to(course_case_path(own_course, Case.last))
+        expect(Case.last.course).to eq(own_course)
+        expect(Case.last.created_by).to eq(plain_instructor)
       end
     end
 
-    context "when accessing case without permission" do
-      let(:other_course) { create(:course, instructor: create(:user, :instructor)) }
+    context "when the instructor does not own the course" do
+      before { sign_in plain_instructor }
+
+      it "denies GET new" do
+        get new_course_case_path(other_course)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq("You are not authorized to perform this action.")
+      end
+
+      it "does not create the case" do
+        expect {
+          post course_cases_path(other_course), params: {case: valid_params}
+        }.not_to change(Case, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "returns 403 for JSON requests" do
+        post course_cases_path(other_course), params: {case: valid_params}, as: :json
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)["error"]).to eq("You are not authorized to perform this action")
+      end
+    end
+
+    context "when the user is a student" do
+      before { sign_in student }
+
+      it "denies GET new" do
+        get new_course_case_path(course)
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "does not create the case" do
+        expect {
+          post course_cases_path(course), params: {case: valid_params}
+        }.not_to change(Case, :count)
+
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "returns 403 rather than a 500 for JSON requests" do
+        post course_cases_path(course), params: {case: valid_params}, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when the user is an org admin for the course's organization" do
+      let(:org_admin) { create(:user, :org_admin, organization: organization) }
+
+      before { sign_in org_admin }
+
+      it "creates the case in a course they do not own" do
+        expect {
+          post course_cases_path(other_course), params: {case: valid_params}
+        }.to change(Case, :count).by(1)
+
+        expect(response).to redirect_to(course_case_path(other_course, Case.last))
+      end
+    end
+
+    context "when the user is an admin" do
+      let(:admin) { create(:user, :admin, organization: organization) }
+
+      before { sign_in admin }
+
+      it "creates the case in any course" do
+        expect {
+          post course_cases_path(other_course), params: {case: valid_params}
+        }.to change(Case, :count).by(1)
+
+        expect(response).to redirect_to(course_case_path(other_course, Case.last))
+      end
+    end
+  end
+
+  describe "authorization integration" do
+    context "when accessing a case in another instructor's course" do
+      let(:other_course) { create(:course, instructor: create(:user, :instructor), course_code: "FOREIGN101") }
       let(:other_case) { create(:case, course: other_course) }
 
       before { sign_in student }
 
-      it "calls authorize method" do
-        expect_any_instance_of(CasesController).to receive(:authorize).with(other_case)
-
-        begin
-          get course_case_path(other_course, other_case)
-        rescue Pundit::NotAuthorizedError
-          # Expected - authorization should fail
-        end
+      it "denies access" do
+        get course_case_path(other_course, other_case)
+        expect(response).to redirect_to(root_path)
       end
     end
   end


### PR DESCRIPTION
## Problem

`CasesController#create` performed no authorization.

- `before_action :authorize_case` covered only `[:show, :edit, :update, :destroy]` — not `:new` or `:create`.
- `set_course` did a bare `Course.find(params[:course_id])` with no check that `current_user` could manage that course.
- `ApplicationController` includes `Pundit::Authorization` but set no `after_action :verify_authorized`.

Net effect: `CasePolicy#create?` was never invoked on the create path. Any signed-in instructor could `POST /courses/:course_id/cases` and create a case in a course they do not own, and `@case.created_by = current_user` then made that user the default team owner via `Simulation#create_default_teams`.

The only thing stopping it from persisting was `Team#owner_must_be_enrolled_in_course` raising `ActiveRecord::RecordInvalid` — a 500, not a clean denial.

## Changes

**`app/policies/case_policy.rb`** — `create?` still gates on instructor/admin, then admins pass through and instructors must satisfy a new `user_can_manage_record_course?`: they own the course (`course.instructor_id == user.id`), or they are an org admin for its organization (`user.can_manage_organization?`, matching what `CoursePolicy#update?` already allows). A record with no course fails closed for instructors. Added `new?` delegating to `create?`.

**`app/controllers/cases_controller.rb`** — `before_action :authorize_new_case, only: [:new, :create]` authorizes a `Case.new(course: @course)` stand-in against `:create?`. It's a fresh object rather than `@course.cases.build` so the association target isn't polluted with a phantom record. Denials now flow through the existing `user_not_authorized` handler: **403 for JSON, redirect + flash for HTML** — no more `RecordInvalid` 500.

Also added `after_action :verify_authorized, except: [:index]` to catch future unauthorized actions, with `skip_authorization` on the collection branches of `background`/`timeline`/`events`.

## Tests

10 new request examples in `spec/requests/cases_spec.rb` covering own-course create (allowed), cross-course instructor (denied, HTML + JSON 403), student (denied, HTML + JSON 403), org admin (allowed), site admin (allowed).

Two pieces of test cleanup were required and are worth a look:

- Removed the nine `allow_any_instance_of(CasesController).to receive(:authorize).and_return(true)` stubs from this file. They defeat `verify_authorized`, and they are precisely what hid this bug — the old "when student tries to create case" example asserted `response.status` was in `[201, 302, 403, 422]` and was passing at 500.
- Rewrote the `CasePolicy#create?` examples to use factory traits. The existing ones pass `role: :admin`, but the role predicates read the `roles` **array column**, so those users had no roles at all — several were already failing on `main` for this reason.

## Verification

Targeted runs (the suite is ~61% failing and CI's `test` job is `continue-on-error: true`, so these are before/after comparisons rather than green/red):

| Spec file | Baseline | After |
|---|---|---|
| `spec/requests/cases_spec.rb` | 27 failures / 52 examples | 26 / 60 |
| `spec/policies/case_policy_spec.rb` | 12 / 21 | 10 / 25 |
| `spec/controllers/cases_controller_spec.rb` | 11 / 18 | unchanged, identical failure list |
| `spec/requests/api/v1/cases_spec.rb` | 12 / 18 | unchanged |

Every remaining failure is present at baseline — missing `tailwind.css` asset in the test env, and `CaseSerializer` calling an undefined `case_team_ids`. Rubocop clean; Brakeman warning count unchanged at 6.

## Notes for the reviewer

`User#assign_first_instructor_as_org_admin` auto-promotes the first instructor in each organization to `org_admin`, and org admins pass `can_manage_organization?`. So in an org whose instructors were seeded that way, this fix is narrower than it reads. That behavior matches `CoursePolicy#update?`, so I kept it and pinned it with an explicit org-admin example rather than changing it silently — but it's worth a decision if you want cases held to a stricter rule than courses.

Separately and out of scope: `CasesController#index` still does a bare `@course.cases` with no policy check when `course_id` is present. Same shape of gap, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)