### PR TITLE
fix(ci): stop hiding test failures in the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
           bin/rails db:test:prepare
       - name: Run tests
         id: tests
-        continue-on-error: true
         run: |
           bundle exec rspec --exclude-pattern spec/e2e/**/*_spec.rb
           bundle exec cucumber


### PR DESCRIPTION
## What

Removes `continue-on-error: true` from the "Run tests" step in `.github/workflows/ci.yml`.

One line. The consequences are not one line.

## Why

That flag meant the `test` job reported success no matter what the suite did. Evidence from this repo's own recent runs:

| PR | rspec result | `test` check |
| --- | --- | --- |
| before #217 | `NameError: uninitialized constant CaseTeam` at load — **0 examples ran** | ✅ pass |
| #217 | 2,063 examples, **1,146 failures** | ✅ pass |
| #235 | 2,063 examples, **1,136 failures** | ✅ pass |

In every case the step itself exited 1. The flag turned that into a green check.

This is how the repo accumulated ~1,100 failing specs and 68 `case_teams` references in application code — including a live 500 on the student dashboard — without anyone finding out. The `e2e` job was red for a year purely because it is the one job that never had the flag.

## What changes for you

**The `test` check will be red on every PR until the suite is green.** That is the intended outcome, but it is a real change to the day-to-day: a red `test` stops being a useful signal in the meantime, and branch protection should not require this check until the failures are cleared.

Current state is roughly 1,095 failures of 2,063 locally, ~1,136 in CI. Progress so far is #217 (spec-side `case_teams` removal, e2e driver) and #235 (application-side `case_teams` removal, in review).

## Deliberately not included

The step still runs three commands in one `run:` block:

```
bundle exec rspec --exclude-pattern spec/e2e/**/*_spec.rb
bundle exec cucumber
bundle exec rails test:system
```

Because the block stops at the first failure, **`cucumber` and `rails test:system` have never executed in any run on record** — rspec has always failed first. Their actual state is still unknown.

Splitting them into three steps is the right follow-up, but it converts one red check into three and deserves its own change and its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test failures now correctly fail the continuous integration check instead of being ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->