### PR TITLE
test: de-flake personality assignment cross-case spec

### DIFF
--- a/spec/services/personality_service_spec.rb
+++ b/spec/services/personality_service_spec.rb
@@ -59,14 +59,33 @@ RSpec.describe PersonalityService, type: :service do
       expect(personalities1).to eq(personalities2)
     end
 
-    it "assigns different personalities to different cases" do
-      case2 = create(:case, :sexual_harassment)
+    # The assignment is a pure function of case.id.hash, and there are only 20
+    # ordered pairs to draw from, so two real cases collide 1 run in 20. Stub the
+    # id to control the seed and test the guarantee the service actually makes:
+    # same id => same pair, and the pair varies with the id.
+    def case_with_seed(seed)
+      seed_id = Object.new
+      seed_id.define_singleton_method(:hash) { seed }
+      instance_double(Case, id: seed_id)
+    end
 
-      personalities1 = PersonalityService.assign_personalities(case_instance)
-      personalities2 = PersonalityService.assign_personalities(case2)
+    it "derives the assignment solely from the case id" do
+      expect(PersonalityService.assign_personalities(case_with_seed(7)))
+        .to eq(PersonalityService.assign_personalities(case_with_seed(7)))
+    end
 
-      # At least one personality should be different between cases
-      expect(personalities1 != personalities2).to be_truthy
+    it "varies the assignment across case ids" do
+      assignments = (0..9).map { |seed| PersonalityService.assign_personalities(case_with_seed(seed)) }
+
+      expect(assignments.uniq.size).to be > 1
+    end
+
+    it "never assigns the same personality to both sides, whatever the case id" do
+      (0..99).each do |seed|
+        personalities = PersonalityService.assign_personalities(case_with_seed(seed))
+
+        expect(personalities[:plaintiff_personality]).not_to eq(personalities[:defendant_personality])
+      end
     end
   end
 


### PR DESCRIPTION
## 📝 Summary
`spec/services/personality_service_spec.rb:61` ("assigns different personalities to different cases") failed roughly 5% of runs. `PersonalityService.assign_personalities` seeds `Random.new(case_instance.id.hash)` from the case's random UUID, then draws a plaintiff personality from 5 types and a defendant personality from the remaining 4 — 20 equally likely ordered pairs, so two independently created cases collide on both picks 1 run in 20. The service never guaranteed distinct assignments across cases, so `expect(personalities1 != personalities2)` was asserting something the code doesn't promise.

Replaced it with three deterministic examples that control the seed directly via a `case_with_seed(seed)` helper — an `instance_double(Case)` whose `id` is an object with a singleton `#hash` returning the seed, so the `Random` stream is fully pinned and no UUID lottery is involved. They cover what the code actually guarantees:

- same id yields the same pair (id-derived, not globally random)
- the pair varies across seeds 0–9 rather than being constant
- plaintiff never equals defendant, across seeds 0–99

No retries, no weakening to a tautology. `PersonalityService` itself is untouched.

Pre-existing and unrelated to the dependency upgrades on #239, but it matters more now that d9d84c1 makes the CI test job actually report failures.

**Related Issue(s):** n/a

## 🎯 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## 🧪 Testing
- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] System tests pass
- [ ] Manual testing completed
- [x] New tests added for new functionality

**Test Instructions:**
1. `PGDATABASE_TEST=bizlaw_test_dep bundle exec rspec spec/services/personality_service_spec.rb -e ".assign_personalities"`
2. Loop it 30 times.
3. Expected: 6 examples, 0 failures on every run. Verified — 30/30 clean. `bin/rubocop` clean on the file.

## 📋 Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No security vulnerabilities introduced
- [ ] Database migrations are reversible (if applicable)
- [ ] Accessibility considerations addressed

## 🎓 Educational Impact
None directly — test-only change. Indirectly, a trustworthy CI signal keeps real regressions in the negotiation simulation from being written off as flake.

## 📸 Screenshots/Demo
n/a

## 🚀 Deployment Notes
None. Spec-only.

## 📎 Additional Context
Four failures remain in this spec file and are **pre-existing** — verified identical on stashed `HEAD`: three in `.build_personality_prompt` and one in `.validate_personality_consistency` ("detects inconsistency" expects falsey, gets `true`). They are out of scope here but will break the test job now that failures are surfaced, so they're worth a separate issue.

The 100-seed invariant loop is brute force over the real code path rather than an argument about it, but it runs in milliseconds and would catch a regression that drops the `available_types - [plaintiff_personality]` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added deterministic coverage for personality assignments.
  * Verified identical case IDs produce consistent assignments.
  * Confirmed different case IDs can produce different assignments.
  * Ensured tested cases do not assign the same personality to both parties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->